### PR TITLE
Customizing HTTP headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,22 @@ func main() {
 	log.Fatal(err)
 }
 
+// snippetCreate add snippetCreate handler function.
 func snippetCreate(w http.ResponseWriter, r *http.Request) {
+	// Use r.Method to check whether the request is using POST or not.
+	if r.Method != http.MethodPost {
+		// If it's not, use the w.WriteHeader() method to send a 405 status
+		// code and the w.Write() method to write a 405 status text
+		// response body. We then return from the function so that the
+		// subsequent code is not executed.
+		w.Header().Set("Allow", http.MethodPost)
+		// Use the http.Error() function to send a 405 status code and
+		// "Method Not Allowed" string as the response body.
+		statusCode := http.StatusMethodNotAllowed
+		http.Error(w, http.StatusText(statusCode), statusCode)
+		return
+	}
+
 	_, _ = w.Write([]byte("Create a new snippet . . . "))
 }
 
@@ -32,9 +47,8 @@ func snippetView(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("Display a specific snippet . . . "))
 }
 
-// snippetCreate add snippetCreate handler function.
 func home(w http.ResponseWriter, r *http.Request) {
-	// Check if the current request URL path exactly maches "/". If it doesn't, use
+	// Check if the current request URL path exactly matches "/". If it doesn't, use
 	// the http.NotFound() function to send a 404 response to the client.
 	// Importantly, we then return from the handler. If we don't return the handler
 	// would keep executing and also write the "Hello from Snippetbox!" message.


### PR DESCRIPTION
#### Follow-up Questions

- How does the method `w.WriteHeader()` work?
- What is the purpose of the HTTP `Allow` header?
- What is the calling order of methods `w.WriteHeader()`, `w.Write()` and `w.Header().Set()`?
- How does the method `http.Error()` work?
- Why should we use status code constants of `net/http` package?